### PR TITLE
CVE-2019-18413. Patch for potential SQL injections

### DIFF
--- a/src/app/sigfox/sigfox-groups-edit/sigfox-groups-edit.component.ts
+++ b/src/app/sigfox/sigfox-groups-edit/sigfox-groups-edit.component.ts
@@ -109,7 +109,7 @@ export class SigfoxGroupsEditComponent implements OnInit, OnDestroy {
       return;
     }
 
-    this.sigfoxService.getGroup(this.sigfoxGroup.id).subscribe(
+    this.sigfoxService.getGroup(this.sigfoxGroupId).subscribe(
       (response: any) => {
         if (response.data.length !== 0 || response.data === undefined) {
           this.update();


### PR DESCRIPTION
Related [backend pull request](https://github.com/OS2iot/OS2IoT-backend/pull/137). I noticed that the id passed to `getGroup` is always undefined. The proper value is most likely `this.signfoxGroupId` which is set when the component is initialized.