### PR TITLE
Fix user list for organization admin

### DIFF
--- a/src/app/admin/admin-routing.module.ts
+++ b/src/app/admin/admin-routing.module.ts
@@ -30,6 +30,7 @@ const adminRoutes: Routes = [
     {
         path: 'users', component: UsersComponent, children: [
             { path: '', component: UserListComponent },
+            { path: 'organization/:organization-id', component: UserListComponent },
             { path: 'new-user', component: UserEditComponent },
             { path: ':user-id', component: UserDetailComponent },
             { path: ':user-id/edit-user', component: UserEditComponent },

--- a/src/app/admin/users/user-list/user-list.component.html
+++ b/src/app/admin/users/user-list/user-list.component.html
@@ -14,7 +14,7 @@
               [component]="true"
               [title]="'USERS.EXISTING-USERS' | translate"
             ></app-top-bar-table>
-            <app-user-table></app-user-table>
+            <app-user-table [organizationId]="organizationId" *ngIf="organizationId"></app-user-table>
           </div>
         </mat-tab>
         <mat-tab label="{{ 'USERS.AWAITING-USERS' | translate }}">

--- a/src/app/admin/users/user-list/user-list.component.ts
+++ b/src/app/admin/users/user-list/user-list.component.ts
@@ -3,6 +3,7 @@ import { Title } from '@angular/platform-browser';
 import { TranslateService } from '@ngx-translate/core';
 import { OrganizationAccessScope } from '@shared/enums/access-scopes';
 import { MeService } from '@shared/services/me.service';
+import { SharedVariableService } from '@shared/shared-variable/shared-variable.service';
 
 @Component({
     selector: 'app-user-list',
@@ -10,14 +11,23 @@ import { MeService } from '@shared/services/me.service';
     styleUrls: ['./user-list.component.scss'],
 })
 export class UserListComponent implements OnInit {
-    canEdit: boolean;
-    constructor(private titleService: Title, private translate: TranslateService, private meService: MeService) {}
+    canEdit: boolean;    
+    organizationId: number;
+
+    constructor(
+        private titleService: Title,
+        private translate: TranslateService,
+        private meService: MeService,
+        private globalService: SharedVariableService
+    ) { 
+        this.organizationId = this.globalService.getSelectedOrganisationId();
+    }
 
     ngOnInit(): void {
         this.translate.get(['TITLE.USER'])
-        .subscribe(translations => {
-          this.titleService.setTitle(translations['TITLE.USER']);
-        });
+            .subscribe(translations => {
+                this.titleService.setTitle(translations['TITLE.USER']);
+            });
         this.canEdit = this.meService.hasAccessToTargetOrganization(OrganizationAccessScope.UserAdministrationWrite);
     }
 }

--- a/src/app/admin/users/user-list/user-table/user-table.component.ts
+++ b/src/app/admin/users/user-list/user-table/user-table.component.ts
@@ -14,6 +14,7 @@ import { merge, Observable, of as observableOf } from 'rxjs';
 import { environment } from '@environments/environment';
 import { DefaultPageSizeOptions } from '@shared/constants/page.constants';
 import { ActivatedRoute } from '@angular/router';
+import { MeService } from '@shared/services/me.service';
 
 @Component({
     selector: 'app-user-table',
@@ -46,11 +47,14 @@ export class UserTableComponent implements AfterViewInit {
     @Input() permissionId?: number;
 
     @Input() canSort = true;
+    isGlobalAdmin: boolean;
 
     constructor(
         public translate: TranslateService,
-        private userService: UserService
+        private userService: UserService,
+        private meService: MeService
     ) {
+        this.isGlobalAdmin = this.meService.hasGlobalAdmin();
     }
 
     getUsers(
@@ -58,13 +62,22 @@ export class UserTableComponent implements AfterViewInit {
         orderByDirection: string
     ): Observable<UserGetManyResponse> {
         if (this.organizationId !== null && this.organizationId !== undefined) {
-            return this.userService.getMultipleByOrganization(
-                this.paginator.pageSize,
-                this.paginator.pageIndex * this.paginator.pageSize,
-                orderByColumn,
-                orderByDirection,
-                this.organizationId
-            );
+            if (this.isGlobalAdmin) {
+                return this.userService.getMultiple(
+                    this.paginator.pageSize,
+                    this.paginator.pageIndex * this.paginator.pageSize,
+                    orderByColumn,
+                    orderByDirection
+                );
+            } else {
+                return this.userService.getMultipleByOrganization(
+                    this.paginator.pageSize,
+                    this.paginator.pageIndex * this.paginator.pageSize,
+                    orderByColumn,
+                    orderByDirection,
+                    this.organizationId
+                );
+            }
         } else {
             return this.userService.getMultiple(
                 this.paginator.pageSize,

--- a/src/app/admin/users/user-list/user-table/user-table.component.ts
+++ b/src/app/admin/users/user-list/user-table/user-table.component.ts
@@ -13,6 +13,7 @@ import { UserService } from '../../user.service';
 import { merge, Observable, of as observableOf } from 'rxjs';
 import { environment } from '@environments/environment';
 import { DefaultPageSizeOptions } from '@shared/constants/page.constants';
+import { ActivatedRoute } from '@angular/router';
 
 @Component({
     selector: 'app-user-table',
@@ -35,27 +36,44 @@ export class UserTableComponent implements AfterViewInit {
     resultsLength = 0;
     isLoadingResults = true;
     @ViewChild(MatPaginator) paginator: MatPaginator;
-    @ViewChild(MatSort) sort: MatSort;
+    @ViewChild(MatSort) sort: MatSort;    
 
+    // If supplied, users will only be retrieved for the specified organization
+    // If supplied, permissionId will ignored, even if supplied
+    @Input() organizationId?: number;
+
+    // If supplied, users will be retrieved on the permissionId (userGroup/brugerGruppe)    
     @Input() permissionId?: number;
+
     @Input() canSort = true;
 
     constructor(
         public translate: TranslateService,
         private userService: UserService
-    ) {}
+    ) {
+    }
 
     getUsers(
         orderByColumn: string,
         orderByDirection: string
     ): Observable<UserGetManyResponse> {
-        return this.userService.getMultiple(
-            this.paginator.pageSize,
-            this.paginator.pageIndex * this.paginator.pageSize,
-            orderByColumn,
-            orderByDirection,
-            this.permissionId
-        );
+        if (this.organizationId !== null && this.organizationId !== undefined) {
+            return this.userService.getMultipleByOrganization(
+                this.paginator.pageSize,
+                this.paginator.pageIndex * this.paginator.pageSize,
+                orderByColumn,
+                orderByDirection,
+                this.organizationId
+            );
+        } else {
+            return this.userService.getMultiple(
+                this.paginator.pageSize,
+                this.paginator.pageIndex * this.paginator.pageSize,
+                orderByColumn,
+                orderByDirection,
+                this.permissionId
+            );
+        }        
     }
 
     ngAfterViewInit() {

--- a/src/app/admin/users/user.service.ts
+++ b/src/app/admin/users/user.service.ts
@@ -51,8 +51,6 @@ export class UserService {
       );
   }
 
-  
-
   getMultiple(
     limit: number = 1000,
     offset: number = 0,
@@ -111,6 +109,24 @@ export class UserService {
     );
   }
 
+  getAwaitingUsersForOrganization(
+    limit: number = 1000,
+    offset: number = 0,
+    organizationId: number,
+    orderByColumn?: string,
+    orderByDirection?: string
+  ): Observable<UserGetManyResponse> {
+    return this.restService.get(
+      `${this.URL}/awaitingUsers/${organizationId}`,
+      {
+        limit,
+        offset,
+        orderOn: orderByColumn,
+        sort: orderByDirection,
+      },
+    );
+  }
+
   getOneSimple(id: number): Observable<UserResponse> {
     return this.restService.get(this.URL_NEW_KOMBIT, {}, id).pipe(
       map((response: UserResponse) => {
@@ -118,6 +134,7 @@ export class UserService {
       })
     );
   }
+
   updateNewKombit(body: CreateNewKombitUserDto): Observable<UserResponse> {
     return this.restService.put(
       this.URL_NEW_KOMBIT + '/createNewKombitUser',

--- a/src/app/admin/users/user.service.ts
+++ b/src/app/admin/users/user.service.ts
@@ -51,13 +51,15 @@ export class UserService {
       );
   }
 
+  
+
   getMultiple(
     limit: number = 1000,
     offset: number = 0,
     orderByColumn?: string,
     orderByDirection?: string,
     permissionId?: number
-  ): Observable<UserGetManyResponse> {
+  ): Observable<UserGetManyResponse> {    
     if (permissionId != null) {
       return this.restService.get(`permission/${permissionId}/users`, {
         limit,
@@ -72,6 +74,21 @@ export class UserService {
       });
     }
   }
+
+  getMultipleByOrganization(
+    limit: number = 1000,
+    offset: number = 0,
+    orderByColumn?: string,
+    orderByDirection?: string,
+    organizationId?: number
+  ): Observable<UserGetManyResponse> {    
+    return this.restService.get(this.URL + `/organizationUsers/${organizationId}`, {
+      limit,
+      offset,
+      orderOn: orderByColumn,
+      sort: orderByDirection,
+    });
+  }  
 
   hideWelcome(id: number): Observable<boolean> {
     return this.restService.put(`${this.URL}/${id}/hide-welcome`, null, null);


### PR DESCRIPTION
User list is now based on the currently selected organization. Thus, an organzation admin can only see the list of users currently in the organization.

Fixes IOT_1197

Also properly fixes sorting the users by name for non Global admins