### PR TITLE
Application contact persons

### DIFF
--- a/src/app/applications/application-detail/application-detail.component.html
+++ b/src/app/applications/application-detail/application-detail.component.html
@@ -32,6 +32,7 @@
               [contactEmail]="application.contactEmail"
               [contactPerson]="application.contactPerson"
               [contactPhone]="application.contactPhone"
+              [contactPersons]="application.contactPersons"
               [controlledProperties]="application.controlledProperties"
               [deviceTypes]="application.deviceTypes"
               [endDate]="application.endDate"

--- a/src/app/applications/application.model.ts
+++ b/src/app/applications/application.model.ts
@@ -7,6 +7,7 @@ import { Organisation } from "../admin/organisation/organisation.model";
 import { ApplicationStatus } from "./enums/status.enum";
 import { IotDevice } from "./iot-devices/iot-device.model";
 import { ApplicationDeviceType } from "./models/application-device-type.model";
+import { ContactPerson } from "../contact-person/contact-person.model";
 
 export type ApplicationWithStatus = Application & { statusCheck: "stable" | "alert" };
 
@@ -30,6 +31,7 @@ export class Application {
   public contactPerson?: string;
   public contactEmail?: string;
   public contactPhone?: string;
+  public contactPersons?: ContactPerson[];
   public personalData?: boolean;
   public hardware?: string;
   public controlledProperties?: ControlledProperty[];
@@ -51,6 +53,7 @@ export class ApplicationRequest {
   public contactPerson?: string;
   public contactEmail?: string;
   public contactPhone?: string;
+  public contactPersons?: ContactPerson[];
   public personalData?: boolean;
   public hardware?: string;
   public controlledProperties?: ControlledPropertyTypes[];

--- a/src/app/applications/application.model.ts
+++ b/src/app/applications/application.model.ts
@@ -53,7 +53,7 @@ export class ApplicationRequest {
   public contactPerson?: string;
   public contactEmail?: string;
   public contactPhone?: string;
-  public contactPersons?: ContactPerson[];
+  public contactPersons?: ContactPerson[] = [];
   public personalData?: boolean;
   public hardware?: string;
   public controlledProperties?: ControlledPropertyTypes[];

--- a/src/app/contact-person/contact-person-edit.component.html
+++ b/src/app/contact-person/contact-person-edit.component.html
@@ -2,61 +2,70 @@
   <div class="row g-2">
     <div class="col-md-6">
       <label class="form-label visually-hidden"
-        [for]="'contact-person-name-'+index">{{ "APPLICATION.METADATA-FIELD.CONTACT-PERSON-NAME" | translate }}</label>
+             [for]="'contact-person-name-'+index">{{ "APPLICATION.METADATA-FIELD.CONTACT-PERSON-NAME" | translate }}</label>
       <input class="form-control"
-        name="name"
-        [id]="'contact-person-name-'+index"
-        type="text"
-        required
-        [(ngModel)]="contactPerson.name"
-        [placeholder]="'APPLICATION.METADATA-FIELD.CONTACT-PERSONS-NAME-PLACEHOLDER' | translate"
-        #name="ngModel"
-        autocomplete="off"/>
+             [id]="'contact-person-name-'+index"
+             type="text"
+             required
+             [(ngModel)]="contactPerson.name"
+             [ngClass]="{
+               'is-invalid': errorMessages && 'name' in errorMessages,
+               'is-valid': errorMessages && !('name' in errorMessages),
+             }"
+             [placeholder]="'APPLICATION.METADATA-FIELD.CONTACT-PERSONS-NAME-PLACEHOLDER' | translate"
+             autocomplete="off"/>
     </div>
 
-  <div class="col-md-6">
-    <label class="form-label visually-hidden"
-           [for]="'contact-person-role-'+index">{{ "APPLICATION.METADATA-FIELD.CONTACT-PERSON-ROLE" | translate }}</label>
-    <input class="form-control"
-           [id]="'contact-person-role-'+index"
-           type="text"
-           [(ngModel)]="contactPerson.role"
-           [placeholder]="'APPLICATION.METADATA-FIELD.CONTACT-PERSONS-ROLE-PLACEHOLDER' | translate"
-           #role="ngModel"
-           autocomplete="off"/>
-  </div>
+    <div class="col-md-6">
+      <label class="form-label visually-hidden"
+             [for]="'contact-person-role-'+index">{{ "APPLICATION.METADATA-FIELD.CONTACT-PERSON-ROLE" | translate }}</label>
+      <input class="form-control"
+             [id]="'contact-person-role-'+index"
+             type="text"
+             [(ngModel)]="contactPerson.role"
+             [ngClass]="{
+          'is-invalid': errorMessages && 'role' in errorMessages,
+          'is-valid': errorMessages && !('role' in errorMessages),
+        }"
+             [placeholder]="'APPLICATION.METADATA-FIELD.CONTACT-PERSONS-ROLE-PLACEHOLDER' | translate"
+             autocomplete="off"/>
+    </div>
 
-  <div class="col-md-6">
-    <label class="form-label visually-hidden"
-           [for]="'contact-person-email-'+index">{{ "APPLICATION.METADATA-FIELD.CONTACT-PERSON-EMAIL" | translate }}</label>
-    <input class="form-control"
-           name="email"
-           [id]="'contact-person-email-'+index"
-           type="email"
-           required
-           [(ngModel)]="contactPerson.email"
-           [placeholder]="'APPLICATION.METADATA-FIELD.CONTACT-PERSONS-EMAIL-PLACEHOLDER' | translate"
-           #email="ngModel"
-           autocomplete="off"/>
-  </div>
+    <div class="col-md-6">
+      <label class="form-label visually-hidden"
+             [for]="'contact-person-email-'+index">{{ "APPLICATION.METADATA-FIELD.CONTACT-PERSON-EMAIL" | translate }}</label>
+      <input class="form-control"
+             [id]="'contact-person-email-'+index"
+             type="email"
+             required
+             [(ngModel)]="contactPerson.email"
+             [ngClass]="{
+               'is-invalid': errorMessages && 'email' in errorMessages,
+               'is-valid': errorMessages && !('email' in errorMessages),
+             }"
+             [placeholder]="'APPLICATION.METADATA-FIELD.CONTACT-PERSONS-EMAIL-PLACEHOLDER' | translate"
+             autocomplete="off"/>
+    </div>
 
-  <div class="col-md-6">
-    <label class="form-label visually-hidden"
-           [for]="'contact-person-phone-'+index">{{ "APPLICATION.METADATA-FIELD.CONTACT-PERSON-PHONE" | translate }}</label>
-    <input class="form-control"
-           name="phone"
-           [id]="'contact-person-phone-'+index"
-           type="tel"
-           required
-           [(ngModel)]="contactPerson.phone"
-           [placeholder]="'APPLICATION.METADATA-FIELD.CONTACT-PERSONS-PHONE-PLACEHOLDER' | translate"
-           #phone="ngModel"
-           autocomplete="off"/>
-  </div>
+    <div class="col-md-6">
+      <label class="form-label visually-hidden"
+             [for]="'contact-person-phone-'+index">{{ "APPLICATION.METADATA-FIELD.CONTACT-PERSON-PHONE" | translate }}</label>
+      <input class="form-control"
+             [id]="'contact-person-phone-'+index"
+             type="tel"
+             required
+             [(ngModel)]="contactPerson.phone"
+             [ngClass]="{
+               'is-invalid': errorMessages && 'phone' in errorMessages,
+               'is-valid': errorMessages && !('phone' in errorMessages),
+             }"
+             [placeholder]="'APPLICATION.METADATA-FIELD.CONTACT-PERSONS-PHONE-PLACEHOLDER' | translate"
+             autocomplete="off"/>
+    </div>
 
-  <div class="col-md-12 mb-4">
-    <button class="float-end btn btn-secondary" type="button" (click)="removeContactPerson()">
-      {{ "APPLICATION.METADATA-FIELD.CONTACT-PERSONS-ACTION-REMOVE" | translate }}
-    </button>
+    <div class="col-md-12 mb-4">
+      <button class="float-end btn btn-secondary" type="button" (click)="removeContactPerson()">
+        {{ "APPLICATION.METADATA-FIELD.CONTACT-PERSONS-ACTION-REMOVE" | translate }}
+      </button>
+    </div>
   </div>
-</div>

--- a/src/app/contact-person/contact-person-edit.component.html
+++ b/src/app/contact-person/contact-person-edit.component.html
@@ -1,0 +1,62 @@
+<div class="contact-person">
+  <div class="row g-2">
+    <div class="col-md-6">
+      <label class="form-label visually-hidden"
+        [for]="'contact-person-name-'+index">{{ "APPLICATION.METADATA-FIELD.CONTACT-PERSON-NAME" | translate }}</label>
+      <input class="form-control"
+        name="name"
+        [id]="'contact-person-name-'+index"
+        type="text"
+        required
+        [(ngModel)]="contactPerson.name"
+        [placeholder]="'APPLICATION.METADATA-FIELD.CONTACT-PERSONS-NAME-PLACEHOLDER' | translate"
+        #name="ngModel"
+        autocomplete="off"/>
+    </div>
+
+  <div class="col-md-6">
+    <label class="form-label visually-hidden"
+           [for]="'contact-person-role-'+index">{{ "APPLICATION.METADATA-FIELD.CONTACT-PERSON-ROLE" | translate }}</label>
+    <input class="form-control"
+           [id]="'contact-person-role-'+index"
+           type="text"
+           [(ngModel)]="contactPerson.role"
+           [placeholder]="'APPLICATION.METADATA-FIELD.CONTACT-PERSONS-ROLE-PLACEHOLDER' | translate"
+           #role="ngModel"
+           autocomplete="off"/>
+  </div>
+
+  <div class="col-md-6">
+    <label class="form-label visually-hidden"
+           [for]="'contact-person-email-'+index">{{ "APPLICATION.METADATA-FIELD.CONTACT-PERSON-EMAIL" | translate }}</label>
+    <input class="form-control"
+           name="email"
+           [id]="'contact-person-email-'+index"
+           type="email"
+           required
+           [(ngModel)]="contactPerson.email"
+           [placeholder]="'APPLICATION.METADATA-FIELD.CONTACT-PERSONS-EMAIL-PLACEHOLDER' | translate"
+           #email="ngModel"
+           autocomplete="off"/>
+  </div>
+
+  <div class="col-md-6">
+    <label class="form-label visually-hidden"
+           [for]="'contact-person-phone-'+index">{{ "APPLICATION.METADATA-FIELD.CONTACT-PERSON-PHONE" | translate }}</label>
+    <input class="form-control"
+           name="phone"
+           [id]="'contact-person-phone-'+index"
+           type="tel"
+           required
+           [(ngModel)]="contactPerson.phone"
+           [placeholder]="'APPLICATION.METADATA-FIELD.CONTACT-PERSONS-PHONE-PLACEHOLDER' | translate"
+           #phone="ngModel"
+           autocomplete="off"/>
+  </div>
+
+  <div class="col-md-12 mb-4">
+    <button class="float-end btn btn-secondary" type="button" (click)="removeContactPerson()">
+      {{ "APPLICATION.METADATA-FIELD.CONTACT-PERSONS-ACTION-REMOVE" | translate }}
+    </button>
+  </div>
+</div>

--- a/src/app/contact-person/contact-person-edit.component.html
+++ b/src/app/contact-person/contact-person-edit.component.html
@@ -1,71 +1,78 @@
-<div class="contact-person">
-  <div class="row g-2">
-    <div class="col-md-6">
-      <label class="form-label visually-hidden"
-             [for]="'contact-person-name-'+index">{{ "APPLICATION.METADATA-FIELD.CONTACT-PERSON-NAME" | translate }}</label>
-      <input class="form-control"
-             [id]="'contact-person-name-'+index"
-             type="text"
-             required
-             [(ngModel)]="contactPerson.name"
-             [ngClass]="{
+<div class="contact-person mb-4">
+  <div class="row">
+    <div class="col-md-10">
+      <div class="row g-2">
+        <div class="col-md-6">
+          <label class="form-label visually-hidden"
+                 [for]="'contact-person-name-'+index">{{ "APPLICATION.METADATA-FIELD.CONTACT-PERSON-NAME" | translate }}</label>
+          <input class="form-control"
+                 [id]="'contact-person-name-'+index"
+                 type="text"
+                 required
+                 [(ngModel)]="contactPerson.name"
+                 [ngClass]="{
                'is-invalid': errorMessages && 'name' in errorMessages,
                'is-valid': errorMessages && !('name' in errorMessages),
              }"
-             [placeholder]="'APPLICATION.METADATA-FIELD.CONTACT-PERSONS-NAME-PLACEHOLDER' | translate"
-             autocomplete="off"/>
-    </div>
+                 [placeholder]="'APPLICATION.METADATA-FIELD.CONTACT-PERSONS-NAME-PLACEHOLDER' | translate"
+                 autocomplete="off"/>
+        </div>
 
-    <div class="col-md-6">
-      <label class="form-label visually-hidden"
-             [for]="'contact-person-role-'+index">{{ "APPLICATION.METADATA-FIELD.CONTACT-PERSON-ROLE" | translate }}</label>
-      <input class="form-control"
-             [id]="'contact-person-role-'+index"
-             type="text"
-             [(ngModel)]="contactPerson.role"
-             [ngClass]="{
+        <div class="col-md-6">
+          <label class="form-label visually-hidden"
+                 [for]="'contact-person-role-'+index">{{ "APPLICATION.METADATA-FIELD.CONTACT-PERSON-ROLE" | translate }}</label>
+          <input class="form-control"
+                 [id]="'contact-person-role-'+index"
+                 type="text"
+                 [(ngModel)]="contactPerson.role"
+                 [ngClass]="{
           'is-invalid': errorMessages && 'role' in errorMessages,
           'is-valid': errorMessages && !('role' in errorMessages),
         }"
-             [placeholder]="'APPLICATION.METADATA-FIELD.CONTACT-PERSONS-ROLE-PLACEHOLDER' | translate"
-             autocomplete="off"/>
-    </div>
+                 [placeholder]="'APPLICATION.METADATA-FIELD.CONTACT-PERSONS-ROLE-PLACEHOLDER' | translate"
+                 autocomplete="off"/>
+        </div>
 
-    <div class="col-md-6">
-      <label class="form-label visually-hidden"
-             [for]="'contact-person-email-'+index">{{ "APPLICATION.METADATA-FIELD.CONTACT-PERSON-EMAIL" | translate }}</label>
-      <input class="form-control"
-             [id]="'contact-person-email-'+index"
-             type="email"
-             required
-             [(ngModel)]="contactPerson.email"
-             [ngClass]="{
+        <div class="col-md-6">
+          <label class="form-label visually-hidden"
+                 [for]="'contact-person-email-'+index">{{ "APPLICATION.METADATA-FIELD.CONTACT-PERSON-EMAIL" | translate }}</label>
+          <input class="form-control"
+                 [id]="'contact-person-email-'+index"
+                 type="email"
+                 required
+                 [(ngModel)]="contactPerson.email"
+                 [ngClass]="{
                'is-invalid': errorMessages && 'email' in errorMessages,
                'is-valid': errorMessages && !('email' in errorMessages),
              }"
-             [placeholder]="'APPLICATION.METADATA-FIELD.CONTACT-PERSONS-EMAIL-PLACEHOLDER' | translate"
-             autocomplete="off"/>
-    </div>
+                 [placeholder]="'APPLICATION.METADATA-FIELD.CONTACT-PERSONS-EMAIL-PLACEHOLDER' | translate"
+                 autocomplete="off"/>
+        </div>
 
-    <div class="col-md-6">
-      <label class="form-label visually-hidden"
-             [for]="'contact-person-phone-'+index">{{ "APPLICATION.METADATA-FIELD.CONTACT-PERSON-PHONE" | translate }}</label>
-      <input class="form-control"
-             [id]="'contact-person-phone-'+index"
-             type="tel"
-             required
-             [(ngModel)]="contactPerson.phone"
-             [ngClass]="{
+        <div class="col-md-6">
+          <label class="form-label visually-hidden"
+                 [for]="'contact-person-phone-'+index">{{ "APPLICATION.METADATA-FIELD.CONTACT-PERSON-PHONE" | translate }}</label>
+          <input class="form-control"
+                 [id]="'contact-person-phone-'+index"
+                 type="tel"
+                 required
+                 [(ngModel)]="contactPerson.phone"
+                 [ngClass]="{
                'is-invalid': errorMessages && 'phone' in errorMessages,
                'is-valid': errorMessages && !('phone' in errorMessages),
              }"
-             [placeholder]="'APPLICATION.METADATA-FIELD.CONTACT-PERSONS-PHONE-PLACEHOLDER' | translate"
-             autocomplete="off"/>
+                 [placeholder]="'APPLICATION.METADATA-FIELD.CONTACT-PERSONS-PHONE-PLACEHOLDER' | translate"
+                 autocomplete="off"/>
+        </div>
+      </div>
+
     </div>
 
-    <div class="col-md-12 mb-4">
-      <button class="float-end btn btn-secondary" type="button" (click)="removeContactPerson()">
-        {{ "APPLICATION.METADATA-FIELD.CONTACT-PERSONS-ACTION-REMOVE" | translate }}
+    <div class="col-md-2">
+      <button class="btn btn-outline-danger" type="button" (click)="removeContactPerson()">
+        <fa-icon [icon]="faTimesCircle"></fa-icon>
+        {{ "GEN.DELETE" | translate}}
       </button>
     </div>
   </div>
+</div>

--- a/src/app/contact-person/contact-person-edit.component.ts
+++ b/src/app/contact-person/contact-person-edit.component.ts
@@ -3,11 +3,13 @@ import { ContactPerson } from "@app/contact-person/contact-person.model";
 import { FormsModule } from "@angular/forms";
 import { TranslatePipe, TranslateService } from "@ngx-translate/core";
 import { NgClass } from "@angular/common";
+import { FaIconComponent } from "@fortawesome/angular-fontawesome";
+import { faTimesCircle } from "@fortawesome/free-solid-svg-icons";
 
 @Component({
   selector: "contact-person-edit",
   templateUrl: "./contact-person-edit.component.html",
-  imports: [TranslatePipe, FormsModule, NgClass],
+  imports: [TranslatePipe, FormsModule, NgClass, FaIconComponent],
 })
 export class ContactPersonEditComponent {
   private translate = inject(TranslateService);
@@ -19,4 +21,6 @@ export class ContactPersonEditComponent {
   @Input() removeContactPerson: () => void;
 
   constructor() {}
+
+  protected readonly faTimesCircle = faTimesCircle;
 }

--- a/src/app/contact-person/contact-person-edit.component.ts
+++ b/src/app/contact-person/contact-person-edit.component.ts
@@ -1,0 +1,21 @@
+import { Component, inject, Input, OnInit } from "@angular/core";
+import { ContactPerson } from "@app/contact-person/contact-person.model";
+import { FormsModule } from "@angular/forms";
+import { _, TranslatePipe, TranslateService } from "@ngx-translate/core";
+import { NgClass } from "@angular/common";
+
+@Component({
+  selector: "contact-person-edit",
+  templateUrl: "./contact-person-edit.component.html",
+  imports: [TranslatePipe, FormsModule, NgClass],
+})
+export class ContactPersonEditComponent {
+  private translate = inject(TranslateService);
+
+  // https://v17.angular.io/guide/component-interaction
+  @Input() index!: number;
+  @Input() contactPerson: ContactPerson;
+  @Input() removeContactPerson: () => void;
+
+  constructor() {}
+}

--- a/src/app/contact-person/contact-person-edit.component.ts
+++ b/src/app/contact-person/contact-person-edit.component.ts
@@ -1,7 +1,7 @@
-import { Component, inject, Input, OnInit } from "@angular/core";
+import { Component, inject, Input } from "@angular/core";
 import { ContactPerson } from "@app/contact-person/contact-person.model";
 import { FormsModule } from "@angular/forms";
-import { _, TranslatePipe, TranslateService } from "@ngx-translate/core";
+import { TranslatePipe, TranslateService } from "@ngx-translate/core";
 import { NgClass } from "@angular/common";
 
 @Component({
@@ -14,6 +14,7 @@ export class ContactPersonEditComponent {
 
   // https://v17.angular.io/guide/component-interaction
   @Input() index!: number;
+  @Input() errorMessages: object;
   @Input() contactPerson: ContactPerson;
   @Input() removeContactPerson: () => void;
 

--- a/src/app/contact-person/contact-person-list-edit.component.html
+++ b/src/app/contact-person/contact-person-list-edit.component.html
@@ -6,7 +6,7 @@
                          [removeContactPerson]="removeContactPerson($index, contactPerson)"/>
   }
 
-  <div class="contact-person add">
+  <div class="contact-person add mb-2">
     <div class="row g-3">
       <div class="col-12">
         <button class="btn btn-secondary" type="button" (click)="addContactPerson()">

--- a/src/app/contact-person/contact-person-list-edit.component.html
+++ b/src/app/contact-person/contact-person-list-edit.component.html
@@ -1,6 +1,7 @@
 <div class="contact-persons">
   @for (contactPerson of contactPersons; track contactPerson) {
     <contact-person-edit [contactPerson]="contactPerson"
+                         [errorMessages]="errorMessages?.[$index]"
                          [index]="$index"
                          [removeContactPerson]="removeContactPerson($index, contactPerson)"/>
   }

--- a/src/app/contact-person/contact-person-list-edit.component.ts
+++ b/src/app/contact-person/contact-person-list-edit.component.ts
@@ -3,6 +3,8 @@ import { ContactPerson } from "@app/contact-person/contact-person.model";
 import { _, TranslatePipe, TranslateService } from "@ngx-translate/core";
 import { FormsModule } from "@angular/forms";
 import { ContactPersonEditComponent } from "@app/contact-person/contact-person-edit.component";
+import { DeleteDialogComponent } from "@shared/components/delete-dialog/delete-dialog.component";
+import { MatDialog } from "@angular/material/dialog";
 
 @Component({
   selector: "contact-person-list-edit",
@@ -16,7 +18,7 @@ export class ContactPersonListEditComponent {
   @Input() contactPersons: ContactPerson[];
   @Input() errorMessages: object;
 
-  constructor() {}
+  constructor(private dialog: MatDialog) {}
 
   addContactPerson(): void {
     this.contactPersons.push(new ContactPerson());
@@ -27,13 +29,28 @@ export class ContactPersonListEditComponent {
       // Ask for confirmation before removing an existing contact person.
       if (contactPerson.id) {
         const message = this.translate
-          .get(_("APPLICATION.METADATA-FIELD.CONTACT-PERSONS-ACTION-REMOVE-CONFIRM"), {
+          .get([
+            _("APPLICATION.METADATA-FIELD.CONTACT-PERSONS-DELETE-CONFIRM"),
+            _("GEN.NO")
+          ], {
             name: contactPerson.name,
           })
-          .subscribe((message: string) => {
-            if (confirm(message)) {
-              this.contactPersons.splice(index, 1);
-            }
+          .subscribe((messages: string[]) => {
+            console.log({messages})
+            const dialog = this.dialog.open(DeleteDialogComponent, {
+              data: {
+                message: messages["APPLICATION.METADATA-FIELD.CONTACT-PERSONS-DELETE-CONFIRM"],
+                showAccept: true,
+                showCancel: true,
+                cancelText: messages["GEN.NO"],
+              },
+            });
+
+            dialog.afterClosed().subscribe(result => {
+              if (result === true) {
+                this.contactPersons.splice(index, 1);
+              }
+            });
           });
       } else {
         this.contactPersons.splice(index, 1);

--- a/src/app/contact-person/contact-person-list-edit.component.ts
+++ b/src/app/contact-person/contact-person-list-edit.component.ts
@@ -1,19 +1,20 @@
-import { Component, inject, Input, OnInit } from "@angular/core";
+import { Component, inject, Input } from "@angular/core";
 import { ContactPerson } from "@app/contact-person/contact-person.model";
 import { _, TranslatePipe, TranslateService } from "@ngx-translate/core";
 import { FormsModule } from "@angular/forms";
 import { ContactPersonEditComponent } from "@app/contact-person/contact-person-edit.component";
 
 @Component({
-  selector: "contact-person-list",
-  templateUrl: "./contact-person-list.component.html",
+  selector: "contact-person-list-edit",
+  templateUrl: "./contact-person-list-edit.component.html",
   imports: [TranslatePipe, FormsModule, ContactPersonEditComponent],
 })
-export class ContactPersonListComponent  {
+export class ContactPersonListEditComponent {
   private translate = inject(TranslateService);
 
   // https://v17.angular.io/guide/component-interaction
   @Input() contactPersons: ContactPerson[];
+  @Input() errorMessages: object;
 
   constructor() {}
 
@@ -37,6 +38,6 @@ export class ContactPersonListComponent  {
       } else {
         this.contactPersons.splice(index, 1);
       }
-    }
+    };
   }
 }

--- a/src/app/contact-person/contact-person-list.component.html
+++ b/src/app/contact-person/contact-person-list.component.html
@@ -1,0 +1,17 @@
+<div class="contact-persons">
+  @for (contactPerson of contactPersons; track contactPerson) {
+    <contact-person-edit [contactPerson]="contactPerson"
+                         [index]="$index"
+                         [removeContactPerson]="removeContactPerson($index, contactPerson)"/>
+  }
+
+  <div class="contact-person add">
+    <div class="row g-3">
+      <div class="col-12">
+        <button class="btn btn-secondary" type="button" (click)="addContactPerson()">
+          {{ "APPLICATION.METADATA-FIELD.CONTACT-PERSONS-ACTION-ADD" | translate }}
+        </button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/app/contact-person/contact-person-list.component.html
+++ b/src/app/contact-person/contact-person-list.component.html
@@ -1,0 +1,24 @@
+<div class="contact-persons">
+  @for (person of contactPersons; track person) {
+    <div class="contact-person mb-4">
+      <div class="row">
+        <div class="col-md-6">
+          {{ person.name }}
+        </div>
+        <div class="col-md-6">
+          {{ person.role }}
+        </div>
+        <div class="col-md-6">
+          @if (person.email) {
+          <a href="mailto:{{ person.email }}">{{ person.email }}</a>
+          }
+        </div>
+        <div class="col-md-6">
+          @if (person.phone) {
+          <a href="tel:{{ person.phone }}">{{ person.phone }}</a>
+          }
+        </div>
+      </div>
+    </div>
+  }
+</div>

--- a/src/app/contact-person/contact-person-list.component.ts
+++ b/src/app/contact-person/contact-person-list.component.ts
@@ -1,0 +1,12 @@
+import { Component, Input } from "@angular/core";
+import { ContactPerson } from "@app/contact-person/contact-person.model";
+import { FormsModule } from "@angular/forms";
+
+@Component({
+  selector: "contact-person-list",
+  templateUrl: "./contact-person-list.component.html",
+  imports: [FormsModule],
+})
+export class ContactPersonListComponent {
+  @Input() contactPersons: ContactPerson[];
+}

--- a/src/app/contact-person/contact-person-list.component.ts
+++ b/src/app/contact-person/contact-person-list.component.ts
@@ -1,0 +1,42 @@
+import { Component, inject, Input, OnInit } from "@angular/core";
+import { ContactPerson } from "@app/contact-person/contact-person.model";
+import { _, TranslatePipe, TranslateService } from "@ngx-translate/core";
+import { FormsModule } from "@angular/forms";
+import { ContactPersonEditComponent } from "@app/contact-person/contact-person-edit.component";
+
+@Component({
+  selector: "contact-person-list",
+  templateUrl: "./contact-person-list.component.html",
+  imports: [TranslatePipe, FormsModule, ContactPersonEditComponent],
+})
+export class ContactPersonListComponent  {
+  private translate = inject(TranslateService);
+
+  // https://v17.angular.io/guide/component-interaction
+  @Input() contactPersons: ContactPerson[];
+
+  constructor() {}
+
+  addContactPerson(): void {
+    this.contactPersons.push(new ContactPerson());
+  }
+
+  removeContactPerson(index: number, contactPerson: ContactPerson): () => void {
+    return () => {
+      // Ask for confirmation before removing an existing contact person.
+      if (contactPerson.id) {
+        const message = this.translate
+          .get(_("APPLICATION.METADATA-FIELD.CONTACT-PERSONS-ACTION-REMOVE-CONFIRM"), {
+            name: contactPerson.name,
+          })
+          .subscribe((message: string) => {
+            if (confirm(message)) {
+              this.contactPersons.splice(index, 1);
+            }
+          });
+      } else {
+        this.contactPersons.splice(index, 1);
+      }
+    }
+  }
+}

--- a/src/app/contact-person/contact-person.model.ts
+++ b/src/app/contact-person/contact-person.model.ts
@@ -1,0 +1,7 @@
+export class ContactPerson {
+  public id: number;
+  public name?: string;
+  public email?: string;
+  public phone?: string;
+  public role?: string;
+}

--- a/src/app/shared/components/forms/form-body-application/form-body-application.component.html
+++ b/src/app/shared/components/forms/form-body-application/form-body-application.component.html
@@ -226,6 +226,13 @@
     </div>
 
     <div class="form-group mt-3">
+      <label class="form-label" for="contactPerson">{{
+          "APPLICATION.METADATA-FIELD.CONTACT-PERSONS" | translate
+        }}</label>
+      <contact-person-list [contactPersons]="application.contactPersons"/>
+    </div>
+
+    <div class="form-group mt-3">
       <label class="form-label" for="application.personalData">{{
           "APPLICATION.METADATA-FIELD.PERSONAL-DATA" | translate
         }}</label>

--- a/src/app/shared/components/forms/form-body-application/form-body-application.component.html
+++ b/src/app/shared/components/forms/form-body-application/form-body-application.component.html
@@ -226,10 +226,11 @@
     </div>
 
     <div class="form-group mt-3">
-      <label class="form-label" for="contactPerson">{{
+      <label class="form-label">{{
           "APPLICATION.METADATA-FIELD.CONTACT-PERSONS" | translate
         }}</label>
-      <contact-person-list [contactPersons]="application.contactPersons"/>
+      <contact-person-list-edit [contactPersons]="application.contactPersons"
+                                [errorMessages]="externalErrorMessages?.['contactPersons'] ?? {}"/>
     </div>
 
     <div class="form-group mt-3">

--- a/src/app/shared/components/forms/form-body-application/form-body-application.component.html
+++ b/src/app/shared/components/forms/form-body-application/form-body-application.component.html
@@ -171,59 +171,67 @@
       />
     </div>
 
-    <div class="form-group mt-3">
-      <label class="form-label" for="contactPerson">{{
-          "APPLICATION.METADATA-FIELD.CONTACT-PERSON" | translate
-        }}</label>
-      <input
-        [(ngModel)]="application.contactPerson"
-        [ngClass]="{
-          'is-invalid': formFailedSubmit && errorFields.includes('application.contactPerson'),
-          'is-valid': formFailedSubmit && !errorFields.includes('application.contactPerson')
-        }"
-        [placeholder]="'QUESTION.APPLICATION.CONTACT-PERSON-PLACEHOLDER' | translate"
-        class="form-control"
-        id="contactPerson"
-        maxlength="100"
-        name="contactPerson"
-        type="text"
-      />
-    </div>
+    <!-- Show deprecated contact person fields only if some are not empty -->
+    @if (application.contactPerson || application.contactEmail || application.contactPhone) {
+      <div class="form-group mt-3">
+        <label class="form-label" for="contactPerson">{{
+            "APPLICATION.METADATA-FIELD.CONTACT-PERSON" | translate
+          }}</label>
+        <input
+          [(ngModel)]="application.contactPerson"
+          [ngClass]="{
+            'is-invalid': formFailedSubmit && errorFields.includes('application.contactPerson'),
+            'is-valid': formFailedSubmit && !errorFields.includes('application.contactPerson')
+          }"
+          [placeholder]="'QUESTION.APPLICATION.CONTACT-PERSON-PLACEHOLDER' | translate"
+          class="form-control"
+          id="contactPerson"
+          maxlength="100"
+          name="contactPerson"
+          type="text"
+        />
+      </div>
 
-    <div class="form-group mt-3">
-      <label class="form-label" for="contactEmail">{{ "APPLICATION.METADATA-FIELD.CONTACT-EMAIL" | translate }}</label>
-      <input
-        [(ngModel)]="application.contactEmail"
-        [email]="true"
-        [ngClass]="{
-          'is-invalid': formFailedSubmit && errorFields.includes('application.contactEmail'),
-          'is-valid': formFailedSubmit && !errorFields.includes('application.contactEmail')
-        }"
-        [placeholder]="'QUESTION.APPLICATION.CONTACT-EMAIL-PLACEHOLDER' | translate"
-        class="form-control"
-        id="contactEmail"
-        maxlength="50"
-        name="contactEmail"
-        type="email"
-      />
-    </div>
+      <div class="form-group mt-3">
+        <label class="form-label" for="contactEmail">{{ "APPLICATION.METADATA-FIELD.CONTACT-EMAIL" | translate }}</label>
+        <input
+          [(ngModel)]="application.contactEmail"
+          [email]="true"
+          [ngClass]="{
+            'is-invalid': formFailedSubmit && errorFields.includes('application.contactEmail'),
+            'is-valid': formFailedSubmit && !errorFields.includes('application.contactEmail')
+          }"
+          [placeholder]="'QUESTION.APPLICATION.CONTACT-EMAIL-PLACEHOLDER' | translate"
+          class="form-control"
+          id="contactEmail"
+          maxlength="50"
+          name="contactEmail"
+          type="email"
+        />
+      </div>
 
-    <div class="form-group mt-3">
-      <label class="form-label" for="contactPhone">{{ "APPLICATION.METADATA-FIELD.CONTACT-PHONE" | translate }}</label>
-      <input
-        [formControl]="phoneCtrl"
-        [ngClass]="{
-          'is-invalid': application.contactPhone && phoneCtrl.invalid,
-          'is-valid': !phoneCtrl.invalid
-        }"
-        [placeholder]="'QUESTION.APPLICATION.CONTACT-PHONE-PLACEHOLDER' | translate"
-        class="form-control"
-        id="contactPhone"
-        maxlength="12"
-        name="contactPhone"
-        type="text"
-      />
-    </div>
+      <div class="form-group mt-3">
+        <label class="form-label" for="contactPhone">{{ "APPLICATION.METADATA-FIELD.CONTACT-PHONE" | translate }}</label>
+        <input
+          [formControl]="phoneCtrl"
+          [ngClass]="{
+            'is-invalid': application.contactPhone && phoneCtrl.invalid,
+            'is-valid': !phoneCtrl.invalid
+          }"
+          [placeholder]="'QUESTION.APPLICATION.CONTACT-PHONE-PLACEHOLDER' | translate"
+          class="form-control"
+          id="contactPhone"
+          maxlength="12"
+          name="contactPhone"
+          type="text"
+        />
+      </div>
+
+      <div class="deprecation-warning">
+        <app-status-icon [iconType]="'alert'"/>
+        {{ "APPLICATION.METADATA-FIELD.CONTACT-PERSON-DEPRECATIONS" | translate }}
+      </div>
+    }
 
     <div class="form-group mt-3">
       <label class="form-label">{{

--- a/src/app/shared/components/forms/form-body-application/form-body-application.component.ts
+++ b/src/app/shared/components/forms/form-body-application/form-body-application.component.ts
@@ -39,9 +39,31 @@ export class FormBodyApplicationComponent implements OnInit, OnDestroy {
   @Input() submitButton: string;
   public payLoad = "";
   public applicationsSubscription: Subscription;
-  public errorMessage: string;
   public errorMessages: string[];
   public errorFields: string[];
+  /**
+   * External error messages, e.g.
+   *
+   * {
+   *   "name": [
+   *     "name must be longer than or equal to 1 characters"
+   *   ],
+   *   "contactPersons": {
+   *     "1": {
+   *       "name": [
+   *         "name should not be empty"
+   *       ],
+   *       "email": [
+   *         "email must be an email"
+   *       ],
+   *       "phone": [
+   *         "phone must be a valid phone number"
+   *       ]
+   *     }
+   *   }
+   * }
+   */
+  public externalErrorMessages: object;
   public formFailedSubmit = false;
   application = new ApplicationRequest();
   model = new User();
@@ -185,8 +207,8 @@ export class FormBodyApplicationComponent implements OnInit, OnDestroy {
       contactPerson.email ??= "";
       contactPerson.phone ??= "";
       if (!contactPerson.name || !contactPerson.email || !contactPerson.phone) {
-          this.handleError(this.buildErrorMessage("Each contact person must have a name, an email and a phone number"), "application.contactPersons["+index+"].name");
-          return;
+        //this.handleError(this.buildErrorMessage("Each contact person must have a name, an email and a phone number"), "application.contactPersons["+index+"].name");
+        //return;
       }
     }
 
@@ -220,10 +242,32 @@ export class FormBodyApplicationComponent implements OnInit, OnDestroy {
     });
   }
 
+  setExternalErrorMessages(errorMessages: object, path: string[], err: any): void {
+    if (err.children && err.children.length > 0) {
+      errorMessages[err.property] = {};
+      err.children.forEach((child: any) =>
+        this.setExternalErrorMessages(errorMessages[err.property], path.concat(err.property), child)
+      );
+    } else if (err.constraints) {
+      const key = path.concat(err.property).join(".");
+      const messages: string[] = Object.values(err.constraints);
+      errorMessages[err.property] = messages;
+
+      if (path.length > 0) {
+        this.errorFields.push(key);
+        this.errorMessages = this.errorMessages.concat(messages);
+      }
+    }
+  }
+
   externalError(error: Pick<HttpErrorResponse, "error">) {
     error.error.message.forEach(err => {
-      this.errorFields.push(err.property);
-      this.errorMessages = this.errorMessages.concat(Object.values(err.constraints));
+      if (err.constraints) {
+        this.errorFields.push(err.property);
+        this.errorMessages = this.errorMessages.concat(Object.values(err.constraints));
+      }
+      this.setExternalErrorMessages(this.externalErrorMessages, [], err);
+      console.debug(this.externalErrorMessages);
     });
     this.formFailedSubmit = true;
   }
@@ -294,6 +338,7 @@ export class FormBodyApplicationComponent implements OnInit, OnDestroy {
   private handleError(error: Pick<HttpErrorResponse, "error">, errorField?: string) {
     this.errorFields = [];
     this.errorMessages = [];
+    this.externalErrorMessages = {};
 
     // Temp fix till we standardise backend error handling
     if (error.error?.message[0]?.property) {

--- a/src/app/shared/components/forms/form-body-application/form-body-application.component.ts
+++ b/src/app/shared/components/forms/form-body-application/form-body-application.component.ts
@@ -172,7 +172,7 @@ export class FormBodyApplicationComponent implements OnInit, OnDestroy {
         this.application.contactPerson = application.contactPerson;
         this.application.contactEmail = application.contactEmail;
         this.application.contactPhone = application.contactPhone;
-        this.application.contactPersons = application.contactPersons;
+        this.application.contactPersons = application.contactPersons ?? [];
         this.phoneCtrl.setValue(application.contactPhone);
         this.application.personalData = application.personalData;
         this.application.hardware = application.hardware;

--- a/src/app/shared/components/forms/form-body-application/form-body-application.component.ts
+++ b/src/app/shared/components/forms/form-body-application/form-body-application.component.ts
@@ -150,6 +150,7 @@ export class FormBodyApplicationComponent implements OnInit, OnDestroy {
         this.application.contactPerson = application.contactPerson;
         this.application.contactEmail = application.contactEmail;
         this.application.contactPhone = application.contactPhone;
+        this.application.contactPersons = application.contactPersons;
         this.phoneCtrl.setValue(application.contactPhone);
         this.application.personalData = application.personalData;
         this.application.hardware = application.hardware;
@@ -176,6 +177,18 @@ export class FormBodyApplicationComponent implements OnInit, OnDestroy {
     this.application.startDate = this.serializedStartDate.value?.toISOString();
     this.application.endDate = this.serializedEndDate.value?.toISOString();
     this.application.contactPhone = this.phoneCtrl.value ? this.phoneCtrl.value : null;
+
+    // @todo Improve this
+    for (const [index, contactPerson] of this.application.contactPersons.entries()) {
+      contactPerson.name ??= "";
+      contactPerson.role ??= "";
+      contactPerson.email ??= "";
+      contactPerson.phone ??= "";
+      if (!contactPerson.name || !contactPerson.email || !contactPerson.phone) {
+          this.handleError(this.buildErrorMessage("Each contact person must have a name, an email and a phone number"), "application.contactPersons["+index+"].name");
+          return;
+      }
+    }
 
     if (this.id) {
       this.updateApplication(this.id);

--- a/src/app/shared/components/forms/form-body-application/form-body-application.component.ts
+++ b/src/app/shared/components/forms/form-body-application/form-body-application.component.ts
@@ -200,18 +200,6 @@ export class FormBodyApplicationComponent implements OnInit, OnDestroy {
     this.application.endDate = this.serializedEndDate.value?.toISOString();
     this.application.contactPhone = this.phoneCtrl.value ? this.phoneCtrl.value : null;
 
-    // @todo Improve this
-    for (const [index, contactPerson] of this.application.contactPersons.entries()) {
-      contactPerson.name ??= "";
-      contactPerson.role ??= "";
-      contactPerson.email ??= "";
-      contactPerson.phone ??= "";
-      if (!contactPerson.name || !contactPerson.email || !contactPerson.phone) {
-        //this.handleError(this.buildErrorMessage("Each contact person must have a name, an email and a phone number"), "application.contactPersons["+index+"].name");
-        //return;
-      }
-    }
-
     if (this.id) {
       this.updateApplication(this.id);
     } else {
@@ -267,7 +255,6 @@ export class FormBodyApplicationComponent implements OnInit, OnDestroy {
         this.errorMessages = this.errorMessages.concat(Object.values(err.constraints));
       }
       this.setExternalErrorMessages(this.externalErrorMessages, [], err);
-      console.debug(this.externalErrorMessages);
     });
     this.formFailedSubmit = true;
   }

--- a/src/app/shared/components/forms/form.module.ts
+++ b/src/app/shared/components/forms/form.module.ts
@@ -11,7 +11,7 @@ import { FormKeyValuePairComponent } from "./form-key-value/form-key-value-pair/
 import { FormKeyValueListComponent } from "./form-key-value/form-key-value-list/form-key-value-list.component";
 import { MatSelectSearchModule } from "@shared/components/mat-select-search/mat-select-search.module";
 import { ContactPersonEditComponent } from "@app/contact-person/contact-person-edit.component";
-import { ContactPersonListComponent } from "@app/contact-person/contact-person-list.component";
+import { ContactPersonListEditComponent } from "@app/contact-person/contact-person-list-edit.component";
 
 @NgModule({
   declarations: [
@@ -30,7 +30,7 @@ import { ContactPersonListComponent } from "@app/contact-person/contact-person-l
     NGMaterialModule,
     MatSelectSearchModule,
     ContactPersonEditComponent,
-    ContactPersonListComponent,
+    ContactPersonListEditComponent,
   ],
   exports: [FormHeaderComponent, FormBodyApplicationComponent, FormKeyValuePairComponent, FormKeyValueListComponent],
   providers: [],

--- a/src/app/shared/components/forms/form.module.ts
+++ b/src/app/shared/components/forms/form.module.ts
@@ -10,6 +10,8 @@ import { FormHeaderComponent } from "./form-header/form-header.component";
 import { FormKeyValuePairComponent } from "./form-key-value/form-key-value-pair/form-key-value-pair.component";
 import { FormKeyValueListComponent } from "./form-key-value/form-key-value-list/form-key-value-list.component";
 import { MatSelectSearchModule } from "@shared/components/mat-select-search/mat-select-search.module";
+import { ContactPersonEditComponent } from "@app/contact-person/contact-person-edit.component";
+import { ContactPersonListComponent } from "@app/contact-person/contact-person-list.component";
 
 @NgModule({
   declarations: [
@@ -27,6 +29,8 @@ import { MatSelectSearchModule } from "@shared/components/mat-select-search/mat-
     TranslatePipe,
     NGMaterialModule,
     MatSelectSearchModule,
+    ContactPersonEditComponent,
+    ContactPersonListComponent,
   ],
   exports: [FormHeaderComponent, FormBodyApplicationComponent, FormKeyValuePairComponent, FormKeyValueListComponent],
   providers: [],

--- a/src/app/shared/components/forms/form.module.ts
+++ b/src/app/shared/components/forms/form.module.ts
@@ -12,6 +12,7 @@ import { FormKeyValueListComponent } from "./form-key-value/form-key-value-list/
 import { MatSelectSearchModule } from "@shared/components/mat-select-search/mat-select-search.module";
 import { ContactPersonEditComponent } from "@app/contact-person/contact-person-edit.component";
 import { ContactPersonListEditComponent } from "@app/contact-person/contact-person-list-edit.component";
+import { StatusIconComponent } from "@shared/components/status-icon/status-icon.component";
 
 @NgModule({
   declarations: [
@@ -31,6 +32,7 @@ import { ContactPersonListEditComponent } from "@app/contact-person/contact-pers
     MatSelectSearchModule,
     ContactPersonEditComponent,
     ContactPersonListEditComponent,
+    StatusIconComponent,
   ],
   exports: [FormHeaderComponent, FormBodyApplicationComponent, FormKeyValuePairComponent, FormKeyValueListComponent],
   providers: [],

--- a/src/app/shared/components/metadata-details/metadata-details.component.html
+++ b/src/app/shared/components/metadata-details/metadata-details.component.html
@@ -53,38 +53,11 @@
 }
 
 @if (contactPersons.length > 0) {
-  <fieldset>
-    <legend>{{ "APPLICATION.METADATA-FIELD.CONTACT-PERSONS" | translate }}</legend>
-
-    @for (person of contactPersons; track person) {
-      <div class="person">
-        @if (person.name) {
-          <p>
-            <strong>{{ "APPLICATION.METADATA-FIELD.CONTACT-PERSON-NAME" | translate }}</strong
-            >{{ person.name }}
-          </p>
-        }
-        @if (person.role) {
-          <p>
-            <strong>{{ "APPLICATION.METADATA-FIELD.CONTACT-PERSON-ROLE" | translate }}</strong
-            >{{ person.role }}
-          </p>
-        }
-@if (person.email) {
-        <p>
-          <strong>{{ "APPLICATION.METADATA-FIELD.CONTACT-PERSON-EMAIL" | translate }}</strong
-          >{{ person.email }}
-        </p>
-      } @if (person.phone) {
-        <p>
-          <strong>{{ "APPLICATION.METADATA-FIELD.CONTACT-PERSON-PHONE" | translate }}</strong
-          >{{ person.phone }}
-        </p>
-      }
-      </div>
-    }
-
-  </fieldset>
+  <p>
+    <strong>{{ "APPLICATION.METADATA-FIELD.CONTACT-PERSONS" | translate }}</strong
+    >
+  </p>
+  <contact-person-list [contactPersons]="contactPersons"/>
 }
 
 <p>

--- a/src/app/shared/components/metadata-details/metadata-details.component.html
+++ b/src/app/shared/components/metadata-details/metadata-details.component.html
@@ -33,7 +33,9 @@
     <strong>{{ "APPLICATION.METADATA-FIELD.OWNER" | translate }}</strong
     >{{ owner }}
   </p>
-} @if (contactPerson) {
+}
+
+@if (contactPerson) {
   <p>
     <strong>{{ "APPLICATION.METADATA-FIELD.CONTACT-PERSON" | translate }}</strong
     >{{ contactPerson }}
@@ -49,6 +51,42 @@
     >{{ contactPhone }}
   </p>
 }
+
+@if (contactPersons.length > 0) {
+  <fieldset>
+    <legend>{{ "APPLICATION.METADATA-FIELD.CONTACT-PERSONS" | translate }}</legend>
+
+    @for (person of contactPersons; track person) {
+      <div class="person">
+        @if (person.name) {
+          <p>
+            <strong>{{ "APPLICATION.METADATA-FIELD.CONTACT-PERSON-NAME" | translate }}</strong
+            >{{ person.name }}
+          </p>
+        }
+        @if (person.role) {
+          <p>
+            <strong>{{ "APPLICATION.METADATA-FIELD.CONTACT-PERSON-ROLE" | translate }}</strong
+            >{{ person.role }}
+          </p>
+        }
+@if (person.email) {
+        <p>
+          <strong>{{ "APPLICATION.METADATA-FIELD.CONTACT-PERSON-EMAIL" | translate }}</strong
+          >{{ person.email }}
+        </p>
+      } @if (person.phone) {
+        <p>
+          <strong>{{ "APPLICATION.METADATA-FIELD.CONTACT-PERSON-PHONE" | translate }}</strong
+          >{{ person.phone }}
+        </p>
+      }
+      </div>
+    }
+
+  </fieldset>
+}
+
 <p>
   <strong>{{ "APPLICATION.METADATA-FIELD.PERSONAL-DATA" | translate }}</strong
   >{{ (personalData ? true.toString() : false.toString()) | translate }}

--- a/src/app/shared/components/metadata-details/metadata-details.component.ts
+++ b/src/app/shared/components/metadata-details/metadata-details.component.ts
@@ -5,6 +5,7 @@ import { ApplicationDeviceType } from "@applications/models/application-device-t
 import { TranslateService } from "@ngx-translate/core";
 import { toPascalKebabCase } from "@shared/helpers/string.helper";
 import { ControlledProperty } from "@shared/models/controlled-property.model";
+import { ContactPerson } from "@app/contact-person/contact-person.model";
 
 @Component({
   selector: "app-metadata-details",
@@ -22,6 +23,7 @@ export class MetadataDetailsComponent implements OnInit {
   @Input() contactPerson?: string;
   @Input() contactEmail?: string;
   @Input() contactPhone?: string;
+  @Input() contactPersons: ContactPerson[];
   @Input() personalData?: boolean;
   @Input() hardware?: string;
   @Input() controlledProperties?: ControlledProperty[];

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -22,6 +22,7 @@ import { TopBarComponent } from "./components/top-bar/top-bar.component";
 import { DirectivesModule } from "./directives/directives.module";
 import { NGMaterialModule } from "./Modules/materiale.module";
 import { PipesModule } from "./pipes/pipes.module";
+import { ContactPersonListComponent } from "@app/contact-person/contact-person-list.component";
 
 @NgModule({
   declarations: [
@@ -49,6 +50,7 @@ import { PipesModule } from "./pipes/pipes.module";
     PipesModule,
     SearchModule,
     MatIconModule,
+    ContactPersonListComponent,
   ],
   exports: [
     AlertComponent,

--- a/src/assets/i18n/da.json
+++ b/src/assets/i18n/da.json
@@ -21,7 +21,9 @@
     "LOG": "Log",
     "MESSAGE": "Besked",
     "DEVICE": "Enhed",
-    "NO-DATA": "Der er ingen data at vise"
+    "NO-DATA": "Der er ingen data at vise",
+    "YES": "Ja",
+    "NO": "Nej"
   },
   "NAV": {
     "APPLICATIONS": "Applikationer",
@@ -170,8 +172,7 @@
       "CONTACT-PERSONS-ROLE-PLACEHOLDER": "Rolle",
 
       "CONTACT-PERSONS-ACTION-ADD": "Tilføj kontaktperson",
-      "CONTACT-PERSONS-ACTION-REMOVE": "Fjern kontaktperson",
-      "CONTACT-PERSONS-ACTION-REMOVE-CONFIRM": "Bekræft at du vil fjerne {{name}} som kontaktperson."
+      "CONTACT-PERSONS-DELETE-CONFIRM": "Er du sikker på at du vil slette {{name}} som kontaktperson?"
     },
     "CHANGE-ORGANIZATION": {
       "TITLE": "Skift organisation",

--- a/src/assets/i18n/da.json
+++ b/src/assets/i18n/da.json
@@ -157,7 +157,21 @@
       "PERSONAL-DATA": "Persondata",
       "HARDWARE": "Hardware",
       "CONTROLLED-PROPERTY": "Data",
-      "DEVICE-TYPE": "Forbindelsesteknologi"
+      "DEVICE-TYPE": "Forbindelsesteknologi",
+      "CONTACT-PERSONS": "Kontaktpersoner",
+      "CONTACT-PERSON-NAME": "Navn",
+      "CONTACT-PERSON-EMAIL": "E-mail",
+      "CONTACT-PERSON-PHONE": "Telefon",
+      "CONTACT-PERSON-ROLE": "Rolle",
+
+      "CONTACT-PERSONS-NAME-PLACEHOLDER": "Navn",
+      "CONTACT-PERSONS-EMAIL-PLACEHOLDER": "E-mail",
+      "CONTACT-PERSONS-PHONE-PLACEHOLDER": "Telefon",
+      "CONTACT-PERSONS-ROLE-PLACEHOLDER": "Rolle",
+
+      "CONTACT-PERSONS-ACTION-ADD": "Tilføj kontaktperson",
+      "CONTACT-PERSONS-ACTION-REMOVE": "Fjern kontaktperson",
+      "CONTACT-PERSONS-ACTION-REMOVE-CONFIRM": "Bekræft at du vil fjerne {{name}} som kontaktperson."
     },
     "CHANGE-ORGANIZATION": {
       "TITLE": "Skift organisation",

--- a/src/assets/i18n/da.json
+++ b/src/assets/i18n/da.json
@@ -156,6 +156,7 @@
       "CONTACT-PERSON": "Kontaktperson",
       "CONTACT-EMAIL": "Kontaktmail",
       "CONTACT-PHONE": "Kontakttelefon",
+      "CONTACT-PERSON-DEPRECATIONS": "Bemærk: Felterne \"Kontaktperson\", \"Kontaktmail\" og \"Kontakttelefon\" er under udfasning. Brug i stedet \"Kontaktpersoner\".",
       "PERSONAL-DATA": "Persondata",
       "HARDWARE": "Hardware",
       "CONTROLLED-PROPERTY": "Data",


### PR DESCRIPTION
> [!IMPORTANT]
> Depends on API changes in https://github.com/OS2iot/OS2iot-backend/pull/295.

Adds (multiple) “contact persons” to an application:

<img width="1070" height="517" alt="Screenshot 2026-03-18 at 15 32 18" src="https://github.com/user-attachments/assets/0d8e98de-eedc-4aec-b627-82582b937e28" />

<img width="1006" height="235" alt="Screenshot 2026-03-20 at 12 57 33" src="https://github.com/user-attachments/assets/91f8f1ed-9896-4a83-97b1-75155e22193e" />

<img width="2042" height="992" alt="image" src="https://github.com/user-attachments/assets/e1ce5651-6355-4841-8b3b-8abdda75193c" />

> [!NOTE]
> We'd like to deprecate the existing contact information fields and therefore we hide the fields if they are all empty. Otherwise we show a message telling the user to use “Contact persons“:
> <img width="2042" height="992" alt="image" src="https://github.com/user-attachments/assets/eb233d6f-022c-465a-aefc-51b8913abcec" />




