### PR TITLE
Add NwkKey field for LoRaWAN 1.1.x OTAA devices

### DIFF
--- a/src/app/applications/iot-devices/iot-device-detail/iot-device-detail-lorawan/iot-device-detail-lorawan.component.html
+++ b/src/app/applications/iot-devices/iot-device-detail/iot-device-detail-lorawan/iot-device-detail-lorawan.component.html
@@ -11,6 +11,12 @@
     <strong>{{ "IOTDEVICE.LORA.OTAAAPPLICATIONKEY" | translate }}</strong
     >{{ device.lorawanSettings?.OTAAapplicationKey }}
   </p>
+  @if (device.lorawanSettings?.OTAAnetworkKey) {
+    <p>
+      <strong>NwkKey (LoRaWAN 1.1.x): </strong
+      >{{ device.lorawanSettings?.OTAAnetworkKey }}
+    </p>
+  }
 } @if (!OTAA) {
   <p>
     <strong>{{ "IOTDEVICE.LORA.DEVADDR" | translate }}</strong

--- a/src/app/applications/iot-devices/iot-device-edit/iot-device-edit.component.html
+++ b/src/app/applications/iot-devices/iot-device-edit/iot-device-edit.component.html
@@ -303,6 +303,24 @@
               type="text"
             />
           </div>
+          @if (isLoRaWAN11) {
+            <div class="form-group mt-5">
+              <label class="form-label" for="OTAAnetworkKey">NwkKey (LoRaWAN 1.1.x root network key)*</label>
+              <input
+                [(ngModel)]="iotDevice.lorawanSettings.OTAAnetworkKey"
+                [ngClass]="{
+                'is-invalid': formFailedSubmit && errorFields.includes('OTAAnetworkKey'),
+                'is-valid': formFailedSubmit && !errorFields.includes('OTAAnetworkKey')
+              }"
+                placeholder="00112233445566778899AABBCCDDEEFF"
+                class="form-control"
+                id="OTAAnetworkKey"
+                maxLength="32"
+                name="OTAAnetworkKey"
+                type="text"
+              />
+            </div>
+          }
         } @if (!OTAA) {
         <h3>{{ "QUESTION.ABP" | translate }}</h3>
         <p>{{ "QUESTION.OTAA-ABP-CONFIG-HELP" | translate }}</p>

--- a/src/app/applications/iot-devices/iot-device-edit/iot-device-edit.component.ts
+++ b/src/app/applications/iot-devices/iot-device-edit/iot-device-edit.component.ts
@@ -42,6 +42,7 @@ export class IotDeviceEditComponent implements OnInit, OnDestroy {
   public loraDevice = DeviceType.LORAWAN;
   public sigfoxDevice = DeviceType.SIGFOX;
   public deviceProfiles: DeviceProfile[];
+  public isLoRaWAN11 = false;
   public deviceModels: DeviceModel[];
   iotDevice = new IotDevice();
   editmode = false;
@@ -142,6 +143,9 @@ export class IotDeviceEditComponent implements OnInit, OnDestroy {
         this.iotDevice.latitude = device.location.coordinates[1];
       }
       this.OTAA = !!this.iotDevice.lorawanSettings?.OTAAapplicationKey;
+      if (this.iotDevice.lorawanSettings?.deviceProfileID) {
+        this.getDeviceProfile(this.iotDevice.lorawanSettings.deviceProfileID);
+      }
       if (device.sigfoxSettings) {
       }
       if (!device.deviceModelId) {
@@ -198,6 +202,7 @@ export class IotDeviceEditComponent implements OnInit, OnDestroy {
   getDeviceProfile(deviceProfileId: string) {
     this.deviceProfileSubscription = this.deviceProfileService.getOne(deviceProfileId).subscribe(response => {
       this.OTAA = response.deviceProfile.supportsJoin;
+      this.isLoRaWAN11 = (response.deviceProfile.macVersion as number) >= 5;
     });
   }
 

--- a/src/app/shared/models/lorawan-settings.model.ts
+++ b/src/app/shared/models/lorawan-settings.model.ts
@@ -5,6 +5,7 @@ export class LorawanSettings {
   skipFCntCheck = false;
   activationType: ActivationType;
   OTAAapplicationKey?: string;
+  OTAAnetworkKey?: string;
   devAddr?: string;
   networkSessionKey?: string;
   applicationSessionKey?: string;


### PR DESCRIPTION
## Problem

Companion til backend-fixet for LoRaWAN 1.1.x OTAA key-mapping (OS2iot/OS2iot-backend#XXX). Frontend skal kunne indtaste den ekstra NwkKey der kræves af LoRaWAN 1.1.x.

## Løsning

* `LorawanSettings`-modellen får `OTAAnetworkKey?: string`.
* Device-edit-formen viser et ekstra "NwkKey"-input når den valgte device-profil rapporterer `mac_version >= LORAWAN_1_1_0` (5).
* `isLoRaWAN11`-flag opdateres både når brugeren vælger profil i dropdown *og* når et eksisterende device loades til redigering — så NwkKey-feltet er synligt og forudfyldt ved edit (ikke kun ved create).
* Detail-viewet viser NwkKey når den er sat.

## Test

1. Opret nyt OTAA-device, vælg en LoRaWAN 1.0.x profil → kun App-felt.
2. Skift profil til 1.1.x → NwkKey-felt dukker op under App-felt.
3. Gem device og åbn det igen i edit → begge felter synlige og udfyldt.
4. Detail-view viser begge nøgler.

## Companion PR

* Backend: OS2iot/OS2iot-backend#298 (selve key-mapping fixet — kør denne PR sammen med backend-PR)
